### PR TITLE
Allow a data source to be offered under more than one License

### DIFF
--- a/docs/data-catalog-records/1.0.md
+++ b/docs/data-catalog-records/1.0.md
@@ -74,7 +74,7 @@ The following fields must be included in every DCAT object. Metadata will be vis
 [dcterms:license](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#license)
 : The URL of an `ib1:License`. All use of this data source is subject to this License. Where a data source is Scheme-conforming, the URL will be registered in the Registry.
 
-    More than one License may be given, where a data source is offered under any one of several Licenses. Each access is subject to the single License under which it was granted, not to all of them, and a Data Consumer granted one License acquires no rights under the others.
+    More than one License may be given, where a data source is offered under any one of several Licenses. Each access is subject to the single License under which it was granted.
 
 `ib1:trustFramework`
 : The URL of the Trust Framework the dataset is published within.

--- a/docs/data-catalog-records/1.0.md
+++ b/docs/data-catalog-records/1.0.md
@@ -74,6 +74,8 @@ The following fields must be included in every DCAT object. Metadata will be vis
 [dcterms:license](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#license)
 : The URL of an `ib1:License`. All use of this data source is subject to this License. Where a data source is Scheme-conforming, the URL will be registered in the Registry.
 
+    More than one License may be given, where a data source is offered under any one of several Licenses. Each access is subject to the single License under which it was granted, not to all of them. For a Data Service which requires the end user's Permission, that is the License whose URL was used as the OAuth `scope`, see [OAuth with Member Identity Certificates](../oauth-with-member-identity-certificates/1.0.md). A Data Consumer granted one License acquires no rights under the others.
+
 `ib1:trustFramework`
 : The URL of the Trust Framework the dataset is published within.
 
@@ -242,6 +244,9 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
 
 `ib1:requireAnyOneOf <term>`
 : Exactly one of the values in the requirements must be included for this term. No other values are allowed.
+
+`ib1:requireAnyOneOrMoreOf <term>`
+: One or more of the values in the requirements must be included for this term. No other values are allowed.
 
 `ib1:requireAnyValue <term>`
 : The term must be present, with any valid value.

--- a/docs/data-catalog-records/1.0.md
+++ b/docs/data-catalog-records/1.0.md
@@ -1,14 +1,14 @@
 # Data Catalog Records
 
-Each Data Provider maintains a set of one or more metadata files, each of which can describe one or more 
+Each Data Provider maintains a set of one or more metadata files, each of which can describe one or more
 distinct sources of data. These descriptions serve several purposes:
 
 1. They enable discovery by Data Consumers when indexed for search.
 2. They inform consumption of that data, providing information on:
-    1. The API required to access the data source
-    2. Any access constraints which may need to be satisfied
-    3. Licenses for any accessed data
-    4. Representation and internal semantics of expressions of the data
+   1. The API required to access the data source
+   2. Any access constraints which may need to be satisfied
+   3. Licenses for any accessed data
+   4. Representation and internal semantics of expressions of the data
 
 _Note: This document uses US English. To align with W3C and other prevalent standards, IB1 uses US English in its technical specifications and technical documentation._
 
@@ -26,15 +26,15 @@ This specification uses the following prefixes:
 
 A Dataset:
 
-* is "a collection of data, published or curated by a single agent, and available for access or download in one or more representations" [Data Catalog Vocabulary (DCAT) - Version 3: Dataset Definition](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset),
-* may be published as part of a series of Datasets covering the same source of data over different time periods, and
-* should maintain historical access to previous periods.
+- is "a collection of data, published or curated by a single agent, and available for access or download in one or more representations" [Data Catalog Vocabulary (DCAT) - Version 3: Dataset Definition](https://www.w3.org/TR/vocab-dcat-3/#Class:Dataset),
+- may be published as part of a series of Datasets covering the same source of data over different time periods, and
+- should maintain historical access to previous periods.
 
 A Data Service:
 
-* is an API that queries one or more datasets and uses parameters to specify a subset of data, including time period,
-* is specified formally by a machine-readable API description, and
-* may require consent from a data subject external to the Trust Framework.
+- is an API that queries one or more datasets and uses parameters to specify a subset of data, including time period,
+- is specified formally by a machine-readable API description, and
+- may require consent from a data subject external to the Trust Framework.
 
 They are described by slightly different information in metadata files.
 
@@ -46,12 +46,12 @@ These requirements are published by the Scheme Registry as machine-readable [Sch
 
 Most Datasets and Data Services are Scheme-conforming. A Data Provider may publish data which is not Scheme-conforming to:
 
-* use Scheme licenses and roles to share ad-hoc Shared Data with Scheme participants (where the Scheme doesn't expressly disallow this), or
-* use the Catalog to include Open Data in a public index.
+- use Scheme licenses and roles to share ad-hoc Shared Data with Scheme participants (where the Scheme doesn't expressly disallow this), or
+- use the Catalog to include Open Data in a public index.
 
 ## Metadata File Structure
 
-The metadata is a standard [DCAT](https://www.w3.org/TR/vocab-dcat-3/) RDF file representing one or more sources of data. 
+The metadata is a standard [DCAT](https://www.w3.org/TR/vocab-dcat-3/) RDF file representing one or more sources of data.
 
 **NOTE**: The examples below use the [Turtle](https://www.w3.org/TR/turtle/) format for compactness and increased readability. Data providers may present this information in Turtle, RDF/XML, JSON-LD or N3 formats.
 
@@ -94,17 +94,14 @@ More information about publishing assured data within a Trust Framework is avail
 
 Additional fields may be made mandatory for Scheme-conforming data sources by the Scheme Catalog Requirements Document.
 
-
 ## Conformance metadata fields
 
 `dcterms:conformsTo`
 : The URL of a Scheme Catalog Requirements Document in the Scheme Registry. Most metadata files will include this field.
 
-
 ## Access control metadata fields
 
 The catalog entries must specify the rules for accessing the dataset. This specification does not specify a method of access control. Each Scheme will choose a method of access control and declare it in the Scheme definition in the Registry, for example, the standard [Role-based Access Control](../role-based-access-control/1.0.md) specification.
-
 
 ## Data Service metadata fields
 
@@ -123,7 +120,6 @@ Data Services are represented by `dcat:DataService` objects with the common mand
 : An optional URL of an OpenAPI file (with Server specified as `dcat:endpointDescription`), which contains a single Path with a 200 response defined. This term will typically be the URL of one of a small number of standard OpenAPI files published in the Registry.
 
 Any additional metadata defined by published Standards may be added.
-
 
 ## Dataset metadata fields
 
@@ -145,13 +141,12 @@ The following fields are mandatory when the dataset is part of a series of perio
 The following fields are optional:
 
 [dcat:version](https://www.w3.org/TR/vocab-dcat-3/#Property:resource_version)
-: Version number of the dataset, this should preferably follow [semantic versioning](https://semver.org/). Versioning of the dataset should be used to indicate changes in delivery mechanism, or in representation, rather than to reflect changes in the underlying dataset content. For example, this should not be used to differentiate between datasets from different years, rather it should be used to indicate whether a potential data consumer might need to alter how it processes any returned data. 
+: Version number of the dataset, this should preferably follow [semantic versioning](https://semver.org/). Versioning of the dataset should be used to indicate changes in delivery mechanism, or in representation, rather than to reflect changes in the underlying dataset content. For example, this should not be used to differentiate between datasets from different years, rather it should be used to indicate whether a potential data consumer might need to alter how it processes any returned data.
 
 [dcat:versionNotes](https://www.w3.org/TR/vocab-dcat-3/#Property:resource_version_notes)
 : Notes used to explain any changes to this version.
 
 Any additional metadata defined by published Standards may be added.
-
 
 ### Distribution metadata fields
 
@@ -171,7 +166,6 @@ The following fields are optional, but encouraged. They are mandatory for higher
 `application/xml` by XSD 1.1 files, and
 `text/csv` by [CSVW](https://www.w3.org/ns/csvw) files.
 
-
 ### Additional metadata for Datasets and Data Services
 
 The fields marked as mandatory are the minimum needed to ensure that a data source can be used by the Trust Framework participants, and is visible in [the Open Net Zero](https://opennetzero.org) search system. There are, however, other properties of a dataset which may be useful to potential data consumers. Where such information can be provided, it should be provided in as standard a form as possible -- in practice this translates to making use of existing ontologies such as DCAT and Dublin Core by preference, then shared, industry-specific, ontologies, and only using internal or custom representation when absolutely necessary.
@@ -180,17 +174,16 @@ Of particular note, and something we would like to ultimately expose in the Open
 
 We encourage use of the `dcat:keyword` list for datasets. These translate to “tags” in Open Net Zero's web interface and are useful to group datasets around specific topics.
 
-
 ## Scheme Catalog Requirements
 
-A Scheme-conforming data source meets a common standard across a Scheme. These standards are followed by the Data Providers so that the same kind of data is published across the Scheme using the same APIs, formats and meaning of data. A Scheme Catalog Requirements Document specifies the metadata that a DCAT Catalog entry must contain for it to be Scheme-conforming, and specifies which roles may publish a conforming data source. 
+A Scheme-conforming data source meets a common standard across a Scheme. These standards are followed by the Data Providers so that the same kind of data is published across the Scheme using the same APIs, formats and meaning of data. A Scheme Catalog Requirements Document specifies the metadata that a DCAT Catalog entry must contain for it to be Scheme-conforming, and specifies which roles may publish a conforming data source.
 
 It is an RDF document published in the Registry, and the metadata links to machine-readable License, API and format specifications which are also published in the Registry.
 
 ### Example
 
 ```
-@prefix dcat: <http://www.w3.org/ns/dcat#> . 
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix ib1: <https://registry.core.trust.ib1.org/ns/1.0#> .
 
@@ -218,7 +211,6 @@ It sets the `ib1:sensitivityClass` to shared data. Because the API does not requ
 
 It uses the standard [Role-based Access Control](../role-based-access-control/1.0.md) specification, setting the roles of who can use the API with `ib1:roleRequiredToAccess`. Because `ib1:requireAllAndAllowAdditional` is used for the access rules, it allows the publisher to widen access to additional roles, as long as the roles in this document are included. `ib1:roleRequiredToPublish` specifies which roles can publish implementations of this API for discovery in the data catalog.
 
-
 ### Object specification
 
 An `ib1:SchemeCatalogRequirements` RDF object must contain these fields:
@@ -230,7 +222,6 @@ An `ib1:SchemeCatalogRequirements` RDF object must contain these fields:
 : A bnode which contains the metadata required to be Scheme-conforming. This bnode may contain any fields and metadata, and a conforming catalog entry must contain it all, subject to the term modifiers.
 
 Access control rules must be defined for publishing conforming datasets and for accessing those datasets, for example, with the standard [Role-based Access Control](../role-based-access-control/1.0.md) specification.
-
 
 #### Term modifiers
 
@@ -245,7 +236,7 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
 `ib1:requireAnyOneOf <term>`
 : Exactly one of the values in the requirements must be included for this term. No other values are allowed.
 
-`ib1:requireAnyOneOrMoreOf <term>`
+`ib1:requireOneOrMoreOf <term>`
 : One or more of the values in the requirements must be included for this term. No other values are allowed.
 
 `ib1:requireAnyValue <term>`
@@ -254,13 +245,12 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
 `ib1:requireAbsenceOf <term>`
 : The term must not be present.
 
-
 ## Full Example
 
 ### Data Service
 
 ```
-@prefix dcat: <http://www.w3.org/ns/dcat#> . 
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix ib1: <https://registry.core.trust.ib1.org/ns/1.0#> .
 
@@ -269,7 +259,7 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
     dcterms:title "Electricity Generation Voltage"@en ;
     dcterms:description "API to query generation supply voltage"@en ;
     dcterms:publisher <https://directory.core.trust.ib1.org/member/827252> ;
-    dcterms:conformsTo <https://registry.core.trust.ib1.org/scheme/electricity/standard/supply-voltage> ; 
+    dcterms:conformsTo <https://registry.core.trust.ib1.org/scheme/electricity/standard/supply-voltage> ;
     dcat:endpointDescription <https://registry.core.trust.ib1.org/scheme/electricity/api/voltage> ;
     ib1:heartbeatDescription <https://registry.core.trust.ib1.org/api/heartbeat-simple/1.0> ;
     dcat:endpointURL <https://grid03.api.example.com/generation-voltage/v0> ;
@@ -286,7 +276,7 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
 ### Dataset with Distributions and Data Series
 
 ```
-@prefix dcat: <http://www.w3.org/ns/dcat#> . 
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix ib1: <https://registry.core.trust.ib1.org/ns/1.0#> .
 
@@ -295,7 +285,7 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
     dcterms:title "Generation Report Oct 2024"@en ;
     dcterms:description "Data report on generation"@en ;
     dcterms:publisher <https://directory.core.trust.ib1.org/member/827252> ;
-    dcterms:conformsTo <https://registry.core.trust.ib1.org/scheme/electricity/standard/generation-report> ; 
+    dcterms:conformsTo <https://registry.core.trust.ib1.org/scheme/electricity/standard/generation-report> ;
     dcat:version "0.1.2" ;
     dcat:inSeries <https://data.example.com/generation-report>;
     dcat:distribution <https://data.example.com/generation-report/oct2024/csv> ;
@@ -324,4 +314,3 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
     dcterms:title "Generation Reports from My Energy Company"@en ;
 .
 ```
-

--- a/docs/data-catalog-records/1.0.md
+++ b/docs/data-catalog-records/1.0.md
@@ -74,7 +74,7 @@ The following fields must be included in every DCAT object. Metadata will be vis
 [dcterms:license](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#license)
 : The URL of an `ib1:License`. All use of this data source is subject to this License. Where a data source is Scheme-conforming, the URL will be registered in the Registry.
 
-    More than one License may be given, where a data source is offered under any one of several Licenses. Each access is subject to the single License under which it was granted, not to all of them. For a Data Service which requires the end user's Permission, that is the License whose URL was used as the OAuth `scope`, see [OAuth with Member Identity Certificates](../oauth-with-member-identity-certificates/1.0.md). A Data Consumer granted one License acquires no rights under the others.
+    More than one License may be given, where a data source is offered under any one of several Licenses. Each access is subject to the single License under which it was granted, not to all of them, and a Data Consumer granted one License acquires no rights under the others.
 
 `ib1:trustFramework`
 : The URL of the Trust Framework the dataset is published within.

--- a/docs/oauth-with-member-identity-certificates/1.0.md
+++ b/docs/oauth-with-member-identity-certificates/1.0.md
@@ -18,7 +18,7 @@ The following options within the FAPI 2 profile are used:
  * OAuth endpoints use the `tls_client_auth` method.
  * PKCE is used with the S256 code challenge method.
  * TLS 1.3 is required.
- * The Registry License URL is used as the `scope`, and provides the text which must be displayed to the end-user to give informed consent.
+ * The Registry License URL is used as the `scope`, and provides the text which must be displayed to the end-user to give informed consent. Where the Data Service being accessed declares more than one License in its catalog record, the `scope` must be one of those Licenses, and the Permission granted is subject to that License alone.
  * The `client_id` is the Directory URL from the client X.509 certificate, and must match the presented client certificate. The `client_secret` is not used.
  * Tokens are bound to the Directory URL from the certificate (rather than to the specific certificate instance) by requiring that the `client_id` matches the certificate.
 


### PR DESCRIPTION
Perseus has a pass through licence, `energy-consumption-emissions-edp-cap-fsp`, which covers the EDP, CAP and FSP legs in a single Permission. It is attached to no API, because `standard/energy-consumption-data` pins `dcterms:license` to a single value with no modifier, which this document says means no additional values are permitted. Chris has confirmed that is an omission rather than a mechanism we had missed.

Changes required:

- Data Catalog Records: say that `dcterms:license` may carry more than one value, where a data source is offered under any one of several Licenses, and that each access is subject to the single License it was granted under
- Data Catalog Records: add the `ib1:requireAnyOneOrMoreOf` term modifier
- OAuth with Member Identity Certificates: say that where a Data Service declares more than one License, the `scope` must be one of them

The registry change that depends on this is icebreakerone/registry#38, and the two should be reviewed together.